### PR TITLE
Derive project for document character route

### DIFF
--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+
+// Use in-memory storage for tests
+process.env.NODE_ENV = 'test';
+// Provide a dummy DATABASE_URL to satisfy db initialization
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/db';
+// Provide dummy Replit domains for auth setup
+process.env.REPLIT_DOMAINS = 'example.com';
+process.env.SESSION_SECRET = 'secret';
+
+// Import storage using test environment
+const { storage } = await import('./storage');
+// Switch to development to avoid auth network calls
+process.env.NODE_ENV = 'development';
+const { registerRoutes } = await import('./routes');
+
+test('GET /api/documents/:documentId/characters uses document\'s project', async () => {
+  const app = express();
+  app.use(express.json());
+  await registerRoutes(app);
+  const server = app.listen(0);
+  const port = (server.address() as any).port;
+
+  // Create a character for the default project's chapter
+  await storage.createCharacter({
+    name: 'Test Character',
+    projectId: 'default-project',
+    role: null,
+    age: null,
+    appearance: null,
+    traits: null,
+    relationships: null,
+    lastMentioned: null,
+  });
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/documents/default-chapter/characters`);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.length, 1);
+  assert.equal(body[0].name, 'Test Character');
+
+  await new Promise(resolve => server.close(resolve));
+});
+
+test('GET /api/documents/:documentId/characters returns 404 for unknown document', async () => {
+  const app = express();
+  app.use(express.json());
+  await registerRoutes(app);
+  const server = app.listen(0);
+  const port = (server.address() as any).port;
+
+  const res = await fetch(`http://127.0.0.1:${port}/api/documents/missing/characters`);
+  assert.equal(res.status, 404);
+
+  await new Promise(resolve => server.close(resolve));
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -193,7 +193,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Keep old route for compatibility
   app.get("/api/documents/:documentId/characters", async (req, res) => {
     try {
-      const characters = await storage.getCharactersByProject("default-project");
+      const { documentId } = req.params;
+
+      // Legacy route: documents are now chapters. Look up the chapter to
+      // determine which project the characters belong to.
+      const chapter = await storage.getChapter(documentId);
+      if (!chapter) {
+        return res.status(404).json({ error: "Document not found" });
+      }
+
+      const characters = await storage.getCharactersByProject(chapter.projectId);
       res.json(characters);
     } catch (error) {
       res.status(500).json({ error: "Failed to fetch characters" });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -661,4 +661,5 @@ As she approached the library door, Sarah noticed something peculiar. The doorkn
   }
 }
 
-export const storage = new DatabaseStorage();
+export const storage: IStorage =
+  process.env.NODE_ENV === "test" ? new MemStorage() : new DatabaseStorage();


### PR DESCRIPTION
## Summary
- Resolve `/api/documents/:documentId/characters` via the chapter's project instead of assuming a default project
- Use in-memory storage when running tests
- Add tests for character retrieval and missing document handling

## Testing
- `npm run check` *(fails: found 11 errors)*
- `NODE_ENV=test node --import tsx --test server/routes.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689f7623884c832d9de9797a86192c17